### PR TITLE
alteração na configuração padrão do plugin maven-install-plugin

### DIFF
--- a/parent/demoiselle/pom.xml
+++ b/parent/demoiselle/pom.xml
@@ -446,7 +446,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-install-plugin</artifactId>
-				<version>${maven-install-plugin}</version>
+				<version>${maven.install.plugin.version}</version>
 				<executions>
 					<execution>
 						<id>default-install</id>
@@ -667,7 +667,7 @@
 		<maven.source.plugin.version>2.1.2</maven.source.plugin.version>
 		<maven.resources.plugin.version>2.5</maven.resources.plugin.version>
 		<maven.cobertura.plugin.version>2.4</maven.cobertura.plugin.version>
-		<maven-install-plugin>2.3.1</maven-install-plugin>
+		<maven.install.plugin.version>2.3.1</maven.install.plugin.version>
 		<wagon.maven.plugin.version>1.0-beta-3</wagon.maven.plugin.version>
 
 		<java.version>1.6</java.version>


### PR DESCRIPTION
alteração na configuração padrão do plugin maven-install-plugin para que
os arquivos .md5 e .sha1 sejam gerados ao copiar os jars para o
repositório local. Em caso de duvicas verificar o item 'Effective POM'
antes e depois da alteração.
